### PR TITLE
Using GraphQL instead CosmosAsync when fetchingDynamicColor

### DIFF
--- a/src/features/colorScheme/dynamicColors/dynamicColors.js
+++ b/src/features/colorScheme/dynamicColors/dynamicColors.js
@@ -116,13 +116,12 @@ const DynamicColors = (() => {
     }
 
     async function fetchDynamicColor(dynamicImageUri) {
+        const { fetchExtractedColors } = Spicetify.GraphQL.Definitions
         try {
-            let rawData = await Spicetify.CosmosAsync.get(
-                encodeURI(
-                    `https://api-partner.spotify.com/pathfinder/v1/query?operationName=fetchExtractedColors&variables={"uris":["${dynamicImageUri}"]}&extensions={"persistedQuery":{"version":1,"sha256Hash":"d7696dd106f3c84a1f3ca37225a1de292e66a2d5aced37a66632585eeb3bbbfa"}}`
-                )
+            let rawData = await Spicetify.GraphQL.Request(
+                fetchExtractedColors,
+                { uris: [dynamicImageUri] },
             )
-
             let extractedColors = rawData.data.extractedColors[0]
             return { dark: extractedColors.colorDark.hex, light: extractedColors.colorLight.hex, raw: extractedColors.colorRaw.hex }
         } catch (err) {


### PR DESCRIPTION
This does not only make code more readable, but also fix an issue that failed to fetch dynamic color from server, which results that we cannot switch theme dynamically.

Although they should do the same thing, the old code will be failed on my spotify 1.2.26.1187.g36b715a1 with spicetify 2.31.3 while the changed one works. Here is the DevTools screenshot which shows the error:
![image](https://github.com/JoshuaWierenga/Nord-Spotify/assets/17194552/d660a221-1d1f-4212-8236-aecf384082f7)

See also: https://spicetify.app/docs/development/api-wrapper/methods/graphql/